### PR TITLE
Use stringify to properly escape downloaded file

### DIFF
--- a/src/Utilities/overviewRows.js
+++ b/src/Utilities/overviewRows.js
@@ -135,7 +135,7 @@ export function multiDownload(selectedRows = {}, onError) {
             const { name, ...file } = files[0] || {};
             if (name) {
                 delete file.latest;
-                fileDownload(file, `${name}-openapi.json`);
+                fileDownload(JSON.stringify(file), `${name}-openapi.json`);
             }
         }
     });


### PR DESCRIPTION
This PR fixes error with `[Object] [Object]` in singe file downloads. Multiple files were not effected by this bug.