### PR TITLE
fix: try it out enabled config

### DIFF
--- a/src/routes/Detail.js
+++ b/src/routes/Detail.js
@@ -144,7 +144,7 @@ const Detail = () => {
               {loaded && (
                 <SwaggerUI
                   deepLinking
-                  tryItOutEnabled={false} // how to use readonly from config?
+                  tryItOutEnabled={false} // how to use api.readonly flag from config?
                   docExpansion="list"
                   spec={spec}
                   requestInterceptor={requestInterceptor}

--- a/src/routes/Detail.js
+++ b/src/routes/Detail.js
@@ -144,6 +144,7 @@ const Detail = () => {
               {loaded && (
                 <SwaggerUI
                   deepLinking
+                  tryItOutEnabled={false} // how to use readonly from config?
                   docExpansion="list"
                   spec={spec}
                   requestInterceptor={requestInterceptor}


### PR DESCRIPTION
Flag provided by swagger can disable try it on for APIs that do not provide valid/server and instance to call. 

While flag is trivial I'm missing info on how I can access config property from component.