### PR TITLE
Fix deep linking by using custom deep links

### DIFF
--- a/src/routes/Detail.js
+++ b/src/routes/Detail.js
@@ -29,7 +29,7 @@ import {
   TextContent,
   Text,
 } from '@patternfly/react-core';
-import { useParams } from 'react-router-dom';
+import { useParams, useNavigate } from 'react-router-dom';
 import { ExternalLinkAltIcon } from '@patternfly/react-icons';
 import ReactJson from 'react-json-view';
 import { useQuery } from '../Utilities/hooks';
@@ -42,6 +42,7 @@ const Detail = () => {
   const error = useSelector(({ detail: { error } }) => error);
   const latest = useSelector(({ detail: { latest } }) => latest);
   const { apiName, version = 'v1' } = useParams();
+  const navigate = useNavigate();
   const query = useQuery();
   const { auth } = useChrome();
   useEffect(() => {
@@ -143,7 +144,6 @@ const Detail = () => {
             <CardBody>
               {loaded && (
                 <SwaggerUI
-                  deepLinking
                   docExpansion="list"
                   spec={spec}
                   requestInterceptor={requestInterceptor}
@@ -152,13 +152,17 @@ const Detail = () => {
                       layoutActions: { show },
                     } = system;
                     system.layoutActions.show = (isShownKey, isShown) => {
-                      const pathName = location.pathname;
+                      const newHash = CSS.escape(isShownKey.join('-'));
+                      const oldHash = location.hash
+                        ?.replace('#', '')
+                        ?.replace(/\\./g, '\\\\.');
                       show(isShownKey, isShown);
-                      history.replaceState(
-                        {},
-                        '',
-                        `${pathName}#${CSS.escape(isShownKey.join('-'))}`
-                      );
+                      if (isShown && newHash !== oldHash) {
+                        navigate(
+                          `/${apiName}/${version}?${query.toString()}#${newHash}`,
+                          { replace: true }
+                        );
+                      }
                     };
 
                     if (location.hash && location.hash.length > 0) {


### PR DESCRIPTION
### Description

When user clicks on a detailed API we are storing active section hash in order for them to bookmark it and send it to others. There's been a bug for quite a while when if user refreshes the page with the hashed value it will fallback to root URL. This is caused by the swagger API implementation when `deepLinking` is enabled they are trying to populate hash in URL. Since we are taking care of it we don't need this behavior so we can disable `deepLinking` and take care of it on our own.