### PR TITLE
Fix error in Caddyfile and add metrics server

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -1,5 +1,5 @@
 {
-    {\$CADDY_TLS_MODE}
+    {$CADDY_TLS_MODE}
     auto_https disable_redirects
 }
 
@@ -8,7 +8,7 @@
   }
   
   :8000 {
-    {\$CADDY_TLS_CERT}
+    {$CADDY_TLS_CERT}
     log
 
     # Handle main app route

--- a/Caddyfile
+++ b/Caddyfile
@@ -1,6 +1,9 @@
 {
     {$CADDY_TLS_MODE}
     auto_https disable_redirects
+    servers {
+        metrics
+    }
 }
 
 :9000 {


### PR DESCRIPTION
This patch removes the leading slash on the TLS env var which is causing the container to crashloop. It also adds the metrics server.