### PR TITLE
[WIP] Add Snyk Parameter to Tekton Config

### DIFF
--- a/.tekton/api-frontend-pull-request.yaml
+++ b/.tekton/api-frontend-pull-request.yaml
@@ -313,8 +313,8 @@ spec:
       params:
       - name: BINARY_IMAGE
         value: $(params.output-image)
-      - name: BASE_IMAGES
-        value: $(tasks.build-container.results.BASE_IMAGES_DIGESTS)
+      # - name: BASE_IMAGES
+      #   value: $(tasks.build-container.results.BASE_IMAGES_DIGESTS)
       runAfter:
       - build-container
       taskRef:
@@ -340,8 +340,8 @@ spec:
         workspace: workspace
     - name: deprecated-base-image-check
       params:
-      - name: BASE_IMAGES_DIGESTS
-        value: $(tasks.build-container.results.BASE_IMAGES_DIGESTS)
+      # - name: BASE_IMAGES_DIGESTS
+      #   value: $(tasks.build-container.results.BASE_IMAGES_DIGESTS)
       - name: IMAGE_URL
         value: $(tasks.build-container.results.IMAGE_URL)
       - name: IMAGE_DIGEST

--- a/.tekton/api-frontend-pull-request.yaml
+++ b/.tekton/api-frontend-pull-request.yaml
@@ -108,10 +108,10 @@ spec:
       description: Java build
       name: java
       type: string
-    - default: "snyk-secret"
-      description: Snyk Token Secret Name
-      name: snyk-secret
-      type: string
+    # - default: "snyk-secret"
+    #   description: Snyk Token Secret Name
+    #   name: snyk-secret
+    #   type: string
     - default: ""
       description: Image tag expiration time, time values could be something like
         1h, 2d, 3w for hours, days, and weeks, respectively.

--- a/.tekton/api-frontend-pull-request.yaml
+++ b/.tekton/api-frontend-pull-request.yaml
@@ -108,6 +108,10 @@ spec:
       description: Java build
       name: java
       type: string
+    - default: "snyk-secret"
+      description: Snyk Token Secret Name
+      name: snyk-secret
+      type: string
     - default: ""
       description: Image tag expiration time, time values could be something like
         1h, 2d, 3w for hours, days, and weeks, respectively.


### PR DESCRIPTION
## Overview

- Adding Snyk Parameter to Tekton Config
   - With the addition of the Snyk Parameter, the Tekton Job can use the Synk SAST scan on pipeline runs.