### PR TITLE
[RHCLOUD-46691] Make documentation readable in dark mode

### DIFF
--- a/src/routes/Detail.tsx
+++ b/src/routes/Detail.tsx
@@ -47,8 +47,13 @@ import { onLoadOneApi } from '../store/actions';
 import { ReduxState } from '../store/store';
 import { BASENAME } from '../Utilities/const';
 import { useQuery } from '../Utilities/hooks';
+import { applySwaggerDarkMode } from '../utils/swaggerDarkMode';
 
 const Detail = () => {
+  useEffect(() => {
+    applySwaggerDarkMode();
+  }, []);
+
   const dispatch = useDispatch();
   const loaded = useSelector(({ detail: { loaded } }: ReduxState) => loaded);
   const spec = useSelector(({ detail: { spec } }: ReduxState) => spec);

--- a/src/utils/swaggerDarkMode.ts
+++ b/src/utils/swaggerDarkMode.ts
@@ -1,0 +1,38 @@
+/**
+ * Invert SwaggerUI values in dark mode so they are readable.
+ *
+ * This function injects CSS at runtime to work around the sassPrefix limitation
+ * in fec.config.js which prevents SCSS files from targeting the <html> element
+ * needed to apply the dark mode styles.
+ *
+ * The injected styles use CSS filters to invert SwaggerUI's hardcoded light theme
+ * colors while preserving semantic hues (green buttons stay green, etc.).
+ *
+ * SwaggerUI doesn't currently natively support custom styling and dark mode.
+ */
+export const applySwaggerDarkMode = () => {
+  const styleId = 'swagger-dark-mode';
+
+  // Only inject if not already present
+  if (document.getElementById(styleId)) {
+    return;
+  }
+
+  const style = document.createElement('style');
+  style.id = styleId;
+  style.textContent = `
+    html.pf-v6-theme-dark .swagger-ui,
+    html.pf-v5-theme-dark .swagger-ui {
+      filter: invert(0.9) hue-rotate(180deg) !important;
+    }
+
+    html.pf-v6-theme-dark .swagger-ui img,
+    html.pf-v5-theme-dark .swagger-ui img,
+    html.pf-v6-theme-dark .swagger-ui svg,
+    html.pf-v5-theme-dark .swagger-ui svg {
+      filter: invert(1) hue-rotate(180deg) !important;
+    }
+  `;
+
+  document.head.appendChild(style);
+};


### PR DESCRIPTION
### Description
<!-- Must include 2-3 sentence summary of proposed changes: what and why. -->
<!-- Must include links to impacted UI(s) or steps to reproduce if applicable. -->

[RHCLOUD-46691](https://redhat.atlassian.net/browse/RHCLOUD-46691)

- Fixes the SwaggerUI generated documentation being unreadable in PatternFly's new dark mode.
---

### Screenshots
<!-- Required for visible UI changes. Before/after or Storybook link. -->
<!-- Delete this section for non-visual changes (pure logic, config, deps). -->

#### Before:
<img width="910" height="592" alt="image" src="https://github.com/user-attachments/assets/222e646d-637c-49b1-8088-844c7d02758f" />


#### After:
<img width="910" height="592" alt="image" src="https://github.com/user-attachments/assets/79a7e7b6-be52-403f-bfff-cc9d648a9e5b" />


---

### Anything reviewers should know?
<!-- Trade-offs, limitations, things that look wrong but are right. -->

This is a temporary fix for the unreadable UI in dark mode. A more robust fix that supports future theming support would likely require a refactor of this that uses PatternFly components in place of SwaggerUI.
(See Swagger UI Dark Mode Support - https://github.com/swagger-api/swagger-ui/pull/10669. Would still not support additional upcoming PatternFly themes)

---

### Checklist
- [x] Accessibility: color contrast, keyboard nav, screen reader tested (or N/A)
- [x] All PR checks pass locally (build, lint, test)
- [x] No unrelated changes included
- [ ] _(Optional) QE: OUIA changed, test impact, no coverage_
- [ ] _(Optional) UX: end-user UX modified, designs need sign-off_

### AI disclosure
<!-- If AI tools contributed, note them. E.g.: Assisted by: Claude Code -->


[RHCLOUD-46691]: https://redhat.atlassian.net/browse/RHCLOUD-46691?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ