### PR TITLE
Update dependency array for docs in the help panel

### DIFF
--- a/src/routes/Detail.tsx
+++ b/src/routes/Detail.tsx
@@ -71,7 +71,7 @@ const Detail = () => {
         },
       })
     );
-  }, []);
+  }, [apiName, version, query, dispatch]);
 
   const requestInterceptor = useCallback(
     async (req: AxiosRequestConfig) => {


### PR DESCRIPTION
I _think_ this will work for [RHCLOUD-47951](https://redhat.atlassian.net/browse/RHCLOUD-47951). Right now, the url and breadcrumb updates when clicking between docs links but not the content itself.

[RHCLOUD-47951]: https://redhat.atlassian.net/browse/RHCLOUD-47951?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ